### PR TITLE
Compiling spectres with Numba

### DIFF
--- a/spectres/__init__.py
+++ b/spectres/__init__.py
@@ -1,1 +1,4 @@
-from .spectral_resampling import spectres
+try:
+    from .spectral_resampling_numba import spectres
+except ImportError:
+    from .spectral_resampling import spectres

--- a/spectres/spectral_resampling_numba.py
+++ b/spectres/spectral_resampling_numba.py
@@ -1,0 +1,157 @@
+from __future__ import print_function, division, absolute_import
+
+import numpy as np
+from numba import jit
+
+@jit(nopython=True, cache=True)
+def make_bins(wavs):
+    """ Given a series of wavelength points, find the edges and widths
+    of corresponding wavelength bins. """
+    edges = np.zeros(wavs.shape[0]+1)
+    widths = np.zeros(wavs.shape[0])
+    edges[0] = wavs[0] - (wavs[1] - wavs[0])/2
+    widths[-1] = (wavs[-1] - wavs[-2])
+    edges[-1] = wavs[-1] + (wavs[-1] - wavs[-2])/2
+    edges[1:-1] = (wavs[1:] + wavs[:-1])/2
+    widths[:-1] = edges[1:-1] - edges[:-2]
+
+    return edges, widths
+
+@jit(nopython=True, cache=True)
+def spectres(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0,
+             verbose=True):
+
+    """
+    Function for resampling spectra (and optionally associated
+    uncertainties) onto a new wavelength basis.
+
+    Parameters
+    ----------
+
+    new_wavs : numpy.ndarray
+        Array containing the new wavelength sampling desired for the
+        spectrum or spectra.
+
+    spec_wavs : numpy.ndarray
+        1D array containing the current wavelength sampling of the
+        spectrum or spectra.
+
+    spec_fluxes : numpy.ndarray
+        Array containing spectral fluxes at the wavelengths specified in
+        spec_wavs, last dimension must correspond to the shape of
+        spec_wavs. Extra dimensions before this may be used to include
+        multiple spectra.
+
+    spec_errs : numpy.ndarray (optional)
+        Array of the same shape as spec_fluxes containing uncertainties
+        associated with each spectral flux value.
+
+    fill : float (optional)
+        Where new_wavs extends outside the wavelength range in spec_wavs
+        this value will be used as a filler in new_fluxes and new_errs.
+
+    verbose : bool (optional)
+        Setting verbose to False will suppress the default warning about
+        new_wavs extending outside spec_wavs and "fill" being used.
+
+    Returns
+    -------
+
+    new_fluxes : numpy.ndarray
+        Array of resampled flux values, first dimension is the same
+        length as new_wavs, other dimensions are the same as
+        spec_fluxes.
+
+    new_errs : numpy.ndarray
+        Array of uncertainties associated with fluxes in new_fluxes.
+        Only returned if spec_errs was specified.
+    """
+
+    # Rename the input variables for clarity within the function.
+    old_wavs = spec_wavs
+    old_fluxes = spec_fluxes
+    old_errs = spec_errs
+
+    # Make arrays of edge positions and widths for the old and new bins
+
+    old_edges, old_widths = make_bins(old_wavs)
+    new_edges, new_widths = make_bins(new_wavs)
+
+    # Generate output arrays to be populated
+    new_fluxes = np.zeros(np.shape(old_fluxes[..., 0]) + np.shape(new_wavs)) #ndarray.shape often doesn't compile properly while np.shape(ndarray) does)
+
+    if old_errs is not None:
+        if old_errs.shape != old_fluxes.shape:
+            raise ValueError("If specified, spec_errs must be the same shape "
+                             "as spec_fluxes.")
+        else:
+            new_errs = np.copy(new_fluxes)
+
+    start = 0
+    stop = 0
+    warned = False
+
+    # Calculate new flux and uncertainty values, looping over new bins
+    for j in range(new_wavs.shape[0]):
+
+        # Add filler values if new_wavs extends outside of spec_wavs
+        if (new_edges[j] < old_edges[0]) or (new_edges[j+1] > old_edges[-1]):
+            new_fluxes[..., j] = fill
+
+            if spec_errs is not None:
+                new_errs[..., j] = fill
+
+            if (j == 0 or j == new_wavs.shape[0]-1) and verbose and not warned:
+                warned = True
+                print("\nSpectres: new_wavs contains values outside the range "
+                      "in spec_wavs, new_fluxes and new_errs will be filled "
+                      "with the value set in the 'fill' keyword argument. \n")
+            continue
+
+        # Find first old bin which is partially covered by the new bin
+        while old_edges[start+1] <= new_edges[j]:
+            start += 1
+
+        # Find last old bin which is partially covered by the new bin
+        while old_edges[stop+1] < new_edges[j+1]:
+            stop += 1
+
+        # If new bin is fully inside an old bin start and stop are equal
+        if stop == start:
+            new_fluxes[..., j] = old_fluxes[..., start]
+            if old_errs is not None:
+                new_errs[..., j] = old_errs[..., start]
+
+        # Otherwise multiply the first and last old bin widths by P_ij
+        else:
+            start_factor = ((old_edges[start+1] - new_edges[j])
+                            / (old_edges[start+1] - old_edges[start]))
+
+            end_factor = ((new_edges[j+1] - old_edges[stop])
+                          / (old_edges[stop+1] - old_edges[stop]))
+
+            old_widths[start] *= start_factor
+            old_widths[stop] *= end_factor
+
+            # Populate new_fluxes spectrum and uncertainty arrays
+            f_widths = old_widths[start:stop+1]*old_fluxes[..., start:stop+1]
+            new_fluxes[..., j] = np.sum(f_widths, axis=-1)
+            new_fluxes[..., j] /= np.sum(old_widths[start:stop+1])
+
+            if old_errs is not None:
+                e_wid = old_widths[start:stop+1]*old_errs[..., start:stop+1]
+
+                new_errs[..., j] = np.sqrt(np.sum(e_wid**2, axis=-1))
+                new_errs[..., j] /= np.sum(old_widths[start:stop+1])
+
+            # Put back the old bin widths to their initial values
+            old_widths[start] /= start_factor
+            old_widths[stop] /= end_factor
+
+    # If errors were supplied return both new_fluxes and new_errs.
+    if old_errs is not None:
+        return new_fluxes, new_errs
+
+    # Otherwise just return the new_fluxes spectrum array
+    else:
+        return new_fluxes

--- a/spectres/spectres_numba_speed_tests.py
+++ b/spectres/spectres_numba_speed_tests.py
@@ -1,0 +1,65 @@
+import numpy as np
+from timeit import timeit, Timer
+
+from spectral_resampling_numba import spectres as spnumba
+from spectral_resampling import spectres as sp
+
+def call_spectres():
+    inwaves = np.linspace(0.5, 15, size)
+    outwaves = np.linspace(1, 10, 200)
+    influxes = np.ones_like(inwaves)
+    r = sp(outwaves, inwaves, influxes)
+    return r
+
+def call_spectres_err():
+    inwaves = np.linspace(0.5, 15, size)
+    outwaves = np.linspace(1, 10, 200)
+    influxes = np.ones_like(inwaves)
+    inerrs = 0.1*influxes
+    r = sp(outwaves, inwaves, influxes, spec_errs = inerrs)
+    return r
+
+
+def call_spectresn():
+    inwaves = np.linspace(0.5, 15, size)
+    outwaves = np.linspace(1, 10, 200)
+    influxes = np.ones_like(inwaves)
+    r = spnumba(outwaves, inwaves, influxes)
+    return r
+
+def call_spectresn_err():
+    inwaves = np.linspace(0.5, 15, size)
+    outwaves = np.linspace(1, 10, 200)
+    influxes = np.ones_like(inwaves)
+    inerrs = 0.1*influxes
+    r = spnumba(outwaves, inwaves, influxes, spec_errs = inerrs)
+    return r
+
+
+if __name__=="__main__":
+    insizes = [1000,10000, 100000]
+    repeats = 1000
+    size = insizes[0]
+    a = call_spectres_err()
+
+    b = call_spectresn_err()
+
+    for size in insizes:
+        
+        print("Running spectres with ",size," input wavelengths for ",repeats," times")
+        timer = Timer(stmt='call_spectres()', setup = 'from spectral_resampling import spectres as sp; from __main__ import call_spectres') 
+        time = timer.timeit(repeats)
+        print("Total runtime = ",time,"s, time per call = ",time/repeats,"s")
+
+        call_spectresn() #Call the compiled version once with the same argument types so that it's ready for the speed test - this could really be done outside the loop
+        print("Running compiled version of spectres with ",size," input wavelengths for ",repeats," times")
+        timer = Timer(stmt='call_spectresn()', setup = 'from spectral_resampling import spectres as sp; from __main__ import call_spectresn')
+        time_c = timer.timeit(repeats)
+
+        print("Total runtime = ",time_c,"s, time per call = ",time_c/repeats,"s")
+        print("Speedup thanks to Numba = ",time/time_c)
+
+        
+        
+
+    


### PR DESCRIPTION
I'm using spectres inside an MCMC and often it's the bottleneck. Having had success with Numba in other codes, I thought it might be able to come to the rescue here too, so I decided to see what would happen if spectres were compiled. 

To this end, I have added a second version of spectres that will be imported if the user has Numba installed. This required a minimum number of changes - switching from using ndarray.shape to np.shape(ndarray) in one place, and forcing fill to have a value (and hence a type so that it can compile). 

The end result is a compiled function that is roughly 20 times faster than the uncompiled one for the (admittedly limited) circumstances I tested.

I hope you find this useful! I'm happy to keep working on this if necessary.