### PR TITLE
Swaps print based warnings for `warnings.warn`

### DIFF
--- a/spectres/spectral_resampling.py
+++ b/spectres/spectral_resampling.py
@@ -4,22 +4,22 @@ import numpy as np
 
 
 def make_bins(wavs):
-    """Given a series of wavelength points, find the edges and widths
-    of corresponding wavelength bins."""
-    edges = np.zeros(wavs.shape[0] + 1)
+    """ Given a series of wavelength points, find the edges and widths
+    of corresponding wavelength bins. """
+    edges = np.zeros(wavs.shape[0]+1)
     widths = np.zeros(wavs.shape[0])
-    edges[0] = wavs[0] - (wavs[1] - wavs[0]) / 2
-    widths[-1] = wavs[-1] - wavs[-2]
-    edges[-1] = wavs[-1] + (wavs[-1] - wavs[-2]) / 2
-    edges[1:-1] = (wavs[1:] + wavs[:-1]) / 2
+    edges[0] = wavs[0] - (wavs[1] - wavs[0])/2
+    widths[-1] = (wavs[-1] - wavs[-2])
+    edges[-1] = wavs[-1] + (wavs[-1] - wavs[-2])/2
+    edges[1:-1] = (wavs[1:] + wavs[:-1])/2
     widths[:-1] = edges[1:-1] - edges[:-2]
 
     return edges, widths
 
 
-def spectres(
-    new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=None, verbose=True
-):
+def spectres(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=None,
+             verbose=True):
+
     """
     Function for resampling spectra (and optionally associated
     uncertainties) onto a new wavelength basis.
@@ -81,10 +81,8 @@ def spectres(
 
     if old_errs is not None:
         if old_errs.shape != old_fluxes.shape:
-            raise ValueError(
-                "If specified, spec_errs must be the same shape "
-                "as spec_fluxes."
-            )
+            raise ValueError("If specified, spec_errs must be the same shape "
+                             "as spec_fluxes.")
         else:
             new_errs = np.copy(new_fluxes)
 
@@ -94,32 +92,27 @@ def spectres(
 
     # Calculate new flux and uncertainty values, looping over new bins
     for j in range(new_wavs.shape[0]):
+
         # Add filler values if new_wavs extends outside of spec_wavs
-        if (new_edges[j] < old_edges[0]) or (new_edges[j + 1] > old_edges[-1]):
+        if (new_edges[j] < old_edges[0]) or (new_edges[j+1] > old_edges[-1]):
             new_fluxes[..., j] = fill
 
             if spec_errs is not None:
                 new_errs[..., j] = fill
 
-            if (
-                (j == 0 or j == new_wavs.shape[0] - 1)
-                and verbose
-                and not warned
-            ):
+            if (j == 0 or j == new_wavs.shape[0]-1) and verbose and not warned:
                 warned = True
-                print(
-                    "\nSpectres: new_wavs contains values outside the range "
-                    "in spec_wavs, new_fluxes and new_errs will be filled "
-                    "with the value set in the 'fill' keyword argument. \n"
-                )
+                print("\nSpectres: new_wavs contains values outside the range "
+                      "in spec_wavs, new_fluxes and new_errs will be filled "
+                      "with the value set in the 'fill' keyword argument. \n")
             continue
 
         # Find first old bin which is partially covered by the new bin
-        while old_edges[start + 1] <= new_edges[j]:
+        while old_edges[start+1] <= new_edges[j]:
             start += 1
 
         # Find last old bin which is partially covered by the new bin
-        while old_edges[stop + 1] < new_edges[j + 1]:
+        while old_edges[stop+1] < new_edges[j+1]:
             stop += 1
 
         # If new bin is fully inside an old bin start and stop are equal
@@ -130,33 +123,25 @@ def spectres(
 
         # Otherwise multiply the first and last old bin widths by P_ij
         else:
-            start_factor = (old_edges[start + 1] - new_edges[j]) / (
-                old_edges[start + 1] - old_edges[start]
-            )
+            start_factor = ((old_edges[start+1] - new_edges[j])
+                            / (old_edges[start+1] - old_edges[start]))
 
-            end_factor = (new_edges[j + 1] - old_edges[stop]) / (
-                old_edges[stop + 1] - old_edges[stop]
-            )
+            end_factor = ((new_edges[j+1] - old_edges[stop])
+                          / (old_edges[stop+1] - old_edges[stop]))
 
             old_widths[start] *= start_factor
             old_widths[stop] *= end_factor
 
             # Populate new_fluxes spectrum and uncertainty arrays
-            f_widths = (
-                old_widths[start : stop + 1]
-                * old_fluxes[..., start : stop + 1]
-            )
+            f_widths = old_widths[start:stop+1]*old_fluxes[..., start:stop+1]
             new_fluxes[..., j] = np.sum(f_widths, axis=-1)
-            new_fluxes[..., j] /= np.sum(old_widths[start : stop + 1])
+            new_fluxes[..., j] /= np.sum(old_widths[start:stop+1])
 
             if old_errs is not None:
-                e_wid = (
-                    old_widths[start : stop + 1]
-                    * old_errs[..., start : stop + 1]
-                )
+                e_wid = old_widths[start:stop+1]*old_errs[..., start:stop+1]
 
                 new_errs[..., j] = np.sqrt(np.sum(e_wid**2, axis=-1))
-                new_errs[..., j] /= np.sum(old_widths[start : stop + 1])
+                new_errs[..., j] /= np.sum(old_widths[start:stop+1])
 
             # Put back the old bin widths to their initial values
             old_widths[start] /= start_factor

--- a/spectres/spectral_resampling.py
+++ b/spectres/spectral_resampling.py
@@ -1,25 +1,31 @@
 from __future__ import print_function, division, absolute_import
+import warnings
 
 import numpy as np
 
 
 def make_bins(wavs):
-    """ Given a series of wavelength points, find the edges and widths
-    of corresponding wavelength bins. """
-    edges = np.zeros(wavs.shape[0]+1)
+    """Given a series of wavelength points, find the edges and widths
+    of corresponding wavelength bins."""
+    edges = np.zeros(wavs.shape[0] + 1)
     widths = np.zeros(wavs.shape[0])
-    edges[0] = wavs[0] - (wavs[1] - wavs[0])/2
-    widths[-1] = (wavs[-1] - wavs[-2])
-    edges[-1] = wavs[-1] + (wavs[-1] - wavs[-2])/2
-    edges[1:-1] = (wavs[1:] + wavs[:-1])/2
+    edges[0] = wavs[0] - (wavs[1] - wavs[0]) / 2
+    widths[-1] = wavs[-1] - wavs[-2]
+    edges[-1] = wavs[-1] + (wavs[-1] - wavs[-2]) / 2
+    edges[1:-1] = (wavs[1:] + wavs[:-1]) / 2
     widths[:-1] = edges[1:-1] - edges[:-2]
 
     return edges, widths
 
 
-def spectres(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=None,
-             verbose=True):
-
+def spectres(
+    new_wavs,
+    spec_wavs,
+    spec_fluxes,
+    spec_errs=None,
+    fill=None,
+    verbose=True,
+):
     """
     Function for resampling spectra (and optionally associated
     uncertainties) onto a new wavelength basis.
@@ -81,38 +87,41 @@ def spectres(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=None,
 
     if old_errs is not None:
         if old_errs.shape != old_fluxes.shape:
-            raise ValueError("If specified, spec_errs must be the same shape "
-                             "as spec_fluxes.")
+            raise ValueError(
+                "If specified, spec_errs must be the same shape "
+                "as spec_fluxes."
+            )
         else:
             new_errs = np.copy(new_fluxes)
 
     start = 0
     stop = 0
-    warned = False
 
     # Calculate new flux and uncertainty values, looping over new bins
     for j in range(new_wavs.shape[0]):
-
         # Add filler values if new_wavs extends outside of spec_wavs
-        if (new_edges[j] < old_edges[0]) or (new_edges[j+1] > old_edges[-1]):
+        if (new_edges[j] < old_edges[0]) or (new_edges[j + 1] > old_edges[-1]):
             new_fluxes[..., j] = fill
 
             if spec_errs is not None:
                 new_errs[..., j] = fill
 
-            if (j == 0 or j == new_wavs.shape[0]-1) and verbose and not warned:
-                warned = True
-                print("\nSpectres: new_wavs contains values outside the range "
-                      "in spec_wavs, new_fluxes and new_errs will be filled "
-                      "with the value set in the 'fill' keyword argument. \n")
+            if (j == 0 or j == new_wavs.shape[0] - 1) and verbose:
+                warnings.warn(
+                    "Spectres: new_wavs contains values outside the range "
+                    "in spec_wavs, new_fluxes and new_errs will be filled "
+                    "with the value set in the 'fill' keyword argument "
+                    "(by default 0).",
+                    category=RuntimeWarning,
+                )
             continue
 
         # Find first old bin which is partially covered by the new bin
-        while old_edges[start+1] <= new_edges[j]:
+        while old_edges[start + 1] <= new_edges[j]:
             start += 1
 
         # Find last old bin which is partially covered by the new bin
-        while old_edges[stop+1] < new_edges[j+1]:
+        while old_edges[stop + 1] < new_edges[j + 1]:
             stop += 1
 
         # If new bin is fully inside an old bin start and stop are equal
@@ -123,25 +132,33 @@ def spectres(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=None,
 
         # Otherwise multiply the first and last old bin widths by P_ij
         else:
-            start_factor = ((old_edges[start+1] - new_edges[j])
-                            / (old_edges[start+1] - old_edges[start]))
+            start_factor = (old_edges[start + 1] - new_edges[j]) / (
+                old_edges[start + 1] - old_edges[start]
+            )
 
-            end_factor = ((new_edges[j+1] - old_edges[stop])
-                          / (old_edges[stop+1] - old_edges[stop]))
+            end_factor = (new_edges[j + 1] - old_edges[stop]) / (
+                old_edges[stop + 1] - old_edges[stop]
+            )
 
             old_widths[start] *= start_factor
             old_widths[stop] *= end_factor
 
             # Populate new_fluxes spectrum and uncertainty arrays
-            f_widths = old_widths[start:stop+1]*old_fluxes[..., start:stop+1]
+            f_widths = (
+                old_widths[start : stop + 1]
+                * old_fluxes[..., start : stop + 1]
+            )
             new_fluxes[..., j] = np.sum(f_widths, axis=-1)
-            new_fluxes[..., j] /= np.sum(old_widths[start:stop+1])
+            new_fluxes[..., j] /= np.sum(old_widths[start : stop + 1])
 
             if old_errs is not None:
-                e_wid = old_widths[start:stop+1]*old_errs[..., start:stop+1]
+                e_wid = (
+                    old_widths[start : stop + 1]
+                    * old_errs[..., start : stop + 1]
+                )
 
                 new_errs[..., j] = np.sqrt(np.sum(e_wid**2, axis=-1))
-                new_errs[..., j] /= np.sum(old_widths[start:stop+1])
+                new_errs[..., j] /= np.sum(old_widths[start : stop + 1])
 
             # Put back the old bin widths to their initial values
             old_widths[start] /= start_factor

--- a/spectres/spectral_resampling.py
+++ b/spectres/spectral_resampling.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division, absolute_import
-import warnings
 
 import numpy as np
 
@@ -19,12 +18,7 @@ def make_bins(wavs):
 
 
 def spectres(
-    new_wavs,
-    spec_wavs,
-    spec_fluxes,
-    spec_errs=None,
-    fill=None,
-    verbose=True,
+    new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=None, verbose=True
 ):
     """
     Function for resampling spectra (and optionally associated
@@ -96,6 +90,7 @@ def spectres(
 
     start = 0
     stop = 0
+    warned = False
 
     # Calculate new flux and uncertainty values, looping over new bins
     for j in range(new_wavs.shape[0]):
@@ -106,13 +101,16 @@ def spectres(
             if spec_errs is not None:
                 new_errs[..., j] = fill
 
-            if (j == 0 or j == new_wavs.shape[0] - 1) and verbose:
-                warnings.warn(
-                    "Spectres: new_wavs contains values outside the range "
+            if (
+                (j == 0 or j == new_wavs.shape[0] - 1)
+                and verbose
+                and not warned
+            ):
+                warned = True
+                print(
+                    "\nSpectres: new_wavs contains values outside the range "
                     "in spec_wavs, new_fluxes and new_errs will be filled "
-                    "with the value set in the 'fill' keyword argument "
-                    "(by default 0).",
-                    category=RuntimeWarning,
+                    "with the value set in the 'fill' keyword argument. \n"
                 )
             continue
 

--- a/spectres/spectral_resampling.py
+++ b/spectres/spectral_resampling.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division, absolute_import
+import warnings
 
 import numpy as np
 
@@ -88,7 +89,6 @@ def spectres(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=None,
 
     start = 0
     stop = 0
-    warned = False
 
     # Calculate new flux and uncertainty values, looping over new bins
     for j in range(new_wavs.shape[0]):
@@ -100,11 +100,14 @@ def spectres(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=None,
             if spec_errs is not None:
                 new_errs[..., j] = fill
 
-            if (j == 0 or j == new_wavs.shape[0]-1) and verbose and not warned:
-                warned = True
-                print("\nSpectres: new_wavs contains values outside the range "
-                      "in spec_wavs, new_fluxes and new_errs will be filled "
-                      "with the value set in the 'fill' keyword argument. \n")
+            if (j == 0 or j == new_wavs.shape[0]-1) and verbose:
+                warnings.warn(
+                    "Spectres: new_wavs contains values outside the range "
+                    "in spec_wavs, new_fluxes and new_errs will be filled "
+                    "with the value set in the 'fill' keyword argument "
+                    "(by default 0).",
+                    category=RuntimeWarning,
+                )
             continue
 
         # Find first old bin which is partially covered by the new bin

--- a/spectres/spectral_resampling_numba.py
+++ b/spectres/spectral_resampling_numba.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division, absolute_import
+import warnings
 
 import numpy as np
 from numba import jit
@@ -110,7 +111,6 @@ def spnumba(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0,
 
     start = 0
     stop = 0
-    warned = False
 
     # Calculate new flux and uncertainty values, looping over new bins
     for j in range(new_wavs.shape[0]):
@@ -122,11 +122,14 @@ def spnumba(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0,
             if spec_errs is not None:
                 new_errs[..., j] = fill
 
-            if (j == 0 or j == new_wavs.shape[0]-1) and verbose and not warned:
-                warned = True
-                print("\nSpectres: new_wavs contains values outside the range "
-                      "in spec_wavs, new_fluxes and new_errs will be filled "
-                      "with the value set in the 'fill' keyword argument. \n")
+            if (j == 0 or j == new_wavs.shape[0]-1) and verbose:
+                warnings.warn(
+                    "Spectres: new_wavs contains values outside the range "
+                    "in spec_wavs, new_fluxes and new_errs will be filled "
+                    "with the value set in the 'fill' keyword argument "
+                    "(by default 0).",
+                    category=RuntimeWarning,
+                )
             continue
 
         # Find first old bin which is partially covered by the new bin

--- a/spectres/spectral_resampling_numba.py
+++ b/spectres/spectral_resampling_numba.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division, absolute_import
-import warnings
 
 import numpy as np
 from numba import jit
@@ -46,12 +45,7 @@ def spectres_numba(
 
 @jit(nopython=True, cache=True)
 def spnumba(
-    new_wavs,
-    spec_wavs,
-    spec_fluxes,
-    spec_errs=None,
-    fill=0,
-    verbose=True,
+    new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0, verbose=True
 ):
     """
     Function for resampling spectra (and optionally associated
@@ -124,6 +118,7 @@ def spnumba(
 
     start = 0
     stop = 0
+    warned = False
 
     # Calculate new flux and uncertainty values, looping over new bins
     for j in range(new_wavs.shape[0]):
@@ -134,13 +129,16 @@ def spnumba(
             if spec_errs is not None:
                 new_errs[..., j] = fill
 
-            if (j == 0 or j == new_wavs.shape[0] - 1) and verbose:
-                warnings.warn(
-                    "Spectres: new_wavs contains values outside the range "
+            if (
+                (j == 0 or j == new_wavs.shape[0] - 1)
+                and verbose
+                and not warned
+            ):
+                warned = True
+                print(
+                    "\nSpectres: new_wavs contains values outside the range "
                     "in spec_wavs, new_fluxes and new_errs will be filled "
-                    "with the value set in the 'fill' keyword argument "
-                    "(by default 0).",
-                    category=RuntimeWarning,
+                    "with the value set in the 'fill' keyword argument. \n"
                 )
             continue
 

--- a/spectres/spectral_resampling_numba.py
+++ b/spectres/spectral_resampling_numba.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division, absolute_import
+import warnings
 
 import numpy as np
 from numba import jit
@@ -6,28 +7,34 @@ from numba import jit
 
 @jit(nopython=True, cache=True)
 def make_bins(wavs):
-    """ Given a series of wavelength points, find the edges and widths
-    of corresponding wavelength bins. """
-    edges = np.zeros(wavs.shape[0]+1)
+    """Given a series of wavelength points, find the edges and widths
+    of corresponding wavelength bins."""
+    edges = np.zeros(wavs.shape[0] + 1)
     widths = np.zeros(wavs.shape[0])
-    edges[0] = wavs[0] - (wavs[1] - wavs[0])/2
-    widths[-1] = (wavs[-1] - wavs[-2])
-    edges[-1] = wavs[-1] + (wavs[-1] - wavs[-2])/2
-    edges[1:-1] = (wavs[1:] + wavs[:-1])/2
+    edges[0] = wavs[0] - (wavs[1] - wavs[0]) / 2
+    widths[-1] = wavs[-1] - wavs[-2]
+    edges[-1] = wavs[-1] + (wavs[-1] - wavs[-2]) / 2
+    edges[1:-1] = (wavs[1:] + wavs[:-1]) / 2
     widths[:-1] = edges[1:-1] - edges[:-2]
 
     return edges, widths
 
 
-def spectres_numba(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0,
-                   verbose=True):
+def spectres_numba(
+    new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0, verbose=True
+):
     """
     Wrapper function to preserve interface when using Numba
     """
 
-    new_fluxes, new_errs = spnumba(new_wavs, spec_wavs, spec_fluxes,
-                                   spec_errs=spec_errs, fill=fill,
-                                   verbose=verbose)
+    new_fluxes, new_errs = spnumba(
+        new_wavs,
+        spec_wavs,
+        spec_fluxes,
+        spec_errs=spec_errs,
+        fill=fill,
+        verbose=verbose,
+    )
 
     # If errors not supplied, only return the fluxes not array of zeros
     if spec_errs is None:
@@ -38,9 +45,14 @@ def spectres_numba(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0,
 
 
 @jit(nopython=True, cache=True)
-def spnumba(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0,
-            verbose=True):
-
+def spnumba(
+    new_wavs,
+    spec_wavs,
+    spec_fluxes,
+    spec_errs=None,
+    fill=0,
+    verbose=True,
+):
     """
     Function for resampling spectra (and optionally associated
     uncertainties) onto a new wavelength basis.
@@ -103,38 +115,41 @@ def spnumba(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0,
 
     if old_errs is not None:
         if old_errs.shape != old_fluxes.shape:
-            raise ValueError("If specified, spec_errs must be the same shape "
-                             "as spec_fluxes.")
+            raise ValueError(
+                "If specified, spec_errs must be the same shape "
+                "as spec_fluxes."
+            )
     #    else:
     new_errs = np.zeros_like(new_fluxes)
 
     start = 0
     stop = 0
-    warned = False
 
     # Calculate new flux and uncertainty values, looping over new bins
     for j in range(new_wavs.shape[0]):
-
         # Add filler values if new_wavs extends outside of spec_wavs
-        if (new_edges[j] < old_edges[0]) or (new_edges[j+1] > old_edges[-1]):
+        if (new_edges[j] < old_edges[0]) or (new_edges[j + 1] > old_edges[-1]):
             new_fluxes[..., j] = fill
 
             if spec_errs is not None:
                 new_errs[..., j] = fill
 
-            if (j == 0 or j == new_wavs.shape[0]-1) and verbose and not warned:
-                warned = True
-                print("\nSpectres: new_wavs contains values outside the range "
-                      "in spec_wavs, new_fluxes and new_errs will be filled "
-                      "with the value set in the 'fill' keyword argument. \n")
+            if (j == 0 or j == new_wavs.shape[0] - 1) and verbose:
+                warnings.warn(
+                    "Spectres: new_wavs contains values outside the range "
+                    "in spec_wavs, new_fluxes and new_errs will be filled "
+                    "with the value set in the 'fill' keyword argument "
+                    "(by default 0).",
+                    category=RuntimeWarning,
+                )
             continue
 
         # Find first old bin which is partially covered by the new bin
-        while old_edges[start+1] <= new_edges[j]:
+        while old_edges[start + 1] <= new_edges[j]:
             start += 1
 
         # Find last old bin which is partially covered by the new bin
-        while old_edges[stop+1] < new_edges[j+1]:
+        while old_edges[stop + 1] < new_edges[j + 1]:
             stop += 1
 
         # If new bin is fully inside an old bin start and stop are equal
@@ -145,25 +160,33 @@ def spnumba(new_wavs, spec_wavs, spec_fluxes, spec_errs=None, fill=0,
 
         # Otherwise multiply the first and last old bin widths by P_ij
         else:
-            start_factor = ((old_edges[start+1] - new_edges[j])
-                            / (old_edges[start+1] - old_edges[start]))
+            start_factor = (old_edges[start + 1] - new_edges[j]) / (
+                old_edges[start + 1] - old_edges[start]
+            )
 
-            end_factor = ((new_edges[j+1] - old_edges[stop])
-                          / (old_edges[stop+1] - old_edges[stop]))
+            end_factor = (new_edges[j + 1] - old_edges[stop]) / (
+                old_edges[stop + 1] - old_edges[stop]
+            )
 
             old_widths[start] *= start_factor
             old_widths[stop] *= end_factor
 
             # Populate new_fluxes spectrum and uncertainty arrays
-            f_widths = old_widths[start:stop+1]*old_fluxes[..., start:stop+1]
+            f_widths = (
+                old_widths[start : stop + 1]
+                * old_fluxes[..., start : stop + 1]
+            )
             new_fluxes[..., j] = np.sum(f_widths, axis=-1)
-            new_fluxes[..., j] /= np.sum(old_widths[start:stop+1])
+            new_fluxes[..., j] /= np.sum(old_widths[start : stop + 1])
 
             if old_errs is not None:
-                e_wid = old_widths[start:stop+1]*old_errs[..., start:stop+1]
+                e_wid = (
+                    old_widths[start : stop + 1]
+                    * old_errs[..., start : stop + 1]
+                )
 
                 new_errs[..., j] = np.sqrt(np.sum(e_wid**2, axis=-1))
-                new_errs[..., j] /= np.sum(old_widths[start:stop+1])
+                new_errs[..., j] /= np.sum(old_widths[start : stop + 1])
 
             # Put back the old bin widths to their initial values
             old_widths[start] /= start_factor


### PR DESCRIPTION
This PR implements warnings using the inbuilt `warnings` package. Functionally the code behaves the same but the user can now handle warnings globally should they want to and the warnings themselves are less intrusive.

The `verbose` argument is now pretty superfluous but I've left it because removing it could break people's scripts. You could add a deprecation warning and remove it later though. In fact, it really should be removed now that the warnings package itself can handle silencing the warnings.

I don't want to tread on toes but the previous warning implementation was getting annoying in our package.

Closes #3.

(My IDE's on-save formatting has made some minor adjustments to some of the formatting. If you want I can undo this.)